### PR TITLE
:green_heart: Remove ci.yml from list of renames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
   ci:
     uses: libhal/ci/.github/workflows/library.yml@3.0.3
     with:
-      library: libhal-__device__
       coverage: true
     secrets: inherit
   deploy:

--- a/.github/workflows/update_name.yml
+++ b/.github/workflows/update_name.yml
@@ -49,6 +49,6 @@ jobs:
         run: rm .github/workflows/update_name.yml
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           title: "Rename device package to libhal-${{ env.device_name }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,6 @@ project(libhal-__device__ VERSION 0.0.1 LANGUAGES CXX)
 find_package(libhal REQUIRED CONFIG)
 find_package(libhal-util REQUIRED CONFIG)
 
-if(NOT BUILD_TESTING STREQUAL OFF)
-  add_subdirectory(tests)
-endif()
-
 add_library(libhal-__device__ src/__device__.cpp)
 
 target_include_directories(libhal-__device__ PUBLIC include)
@@ -32,5 +28,9 @@ target_link_libraries(libhal-__device__ PRIVATE
   libhal::libhal
   libhal::util
 )
+
+if(NOT BUILD_TESTING STREQUAL OFF)
+  add_subdirectory(tests)
+endif()
 
 install(TARGETS libhal-__device__)

--- a/conanfile.py
+++ b/conanfile.py
@@ -73,6 +73,7 @@ class libhal___device___conan(ConanFile):
     def requirements(self):
         self.requires("libhal/[^2.0.0]")
         self.build_requires("libhal-util/[^2.1.0]")
+        self.tool_requires("libhal-cmake-util/1.0.0")
         self.test_requires("libhal-mock/[^2.0.0]")
         self.test_requires("boost-ext-ut/1.1.9")
 

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -16,31 +16,42 @@ cmake_minimum_required(VERSION 3.20)
 
 project(demos VERSION 0.0.1 LANGUAGES CXX)
 
-find_package(libhal-lpc40 REQUIRED CONFIG)
+set(platform_library $ENV{LIBHAL_PLATFORM_LIBRARY})
+set(platform $ENV{LIBHAL_PLATFORM})
+
+message(WARNING "${platform_library}")
+
+if("${platform_library}" STREQUAL "")
+    message(FATAL_ERROR
+        "Build environment variable LIBHAL_PLATFORM_LIBRARY is required for " "this project.")
+endif()
+
+find_package(libhal-${platform_library} REQUIRED CONFIG)
 find_package(libhal-__device__ REQUIRED CONFIG)
 find_package(libhal-util REQUIRED CONFIG)
 
 set(DEMOS __device__)
-set(TARGETS lpc4078 lpc4074)
 
-foreach(target IN LISTS TARGETS)
-    foreach(demo IN LISTS DEMOS)
-        set(current_project ${target}_${demo}.elf)
-        message(STATUS "Generating Demo for \"${current_project}\"")
-        add_executable(${current_project}
-            main.cpp
-            newlib.cpp
-            targets/${target}/initializer.cpp
-            applications/${demo}.cpp)
-        target_include_directories(${current_project} PUBLIC
-            ./
-            targets/${target})
-        target_compile_features(${current_project} PRIVATE cxx_std_20)
-        target_link_options(${current_project} PRIVATE -u _printf_float)
-        target_link_libraries(${current_project} PRIVATE
-            libhal::${target}
-            libhal::__device__
-            libhal::util)
-        arm_post_build(${current_project})
-    endforeach()
+add_library(startup_code
+    main.cpp
+    targets/${platform}.cpp)
+target_include_directories(startup_code PUBLIC .)
+target_compile_features(startup_code PRIVATE cxx_std_20)
+target_link_libraries(startup_code PRIVATE
+    libhal::${platform_library}
+    libhal::__device__
+    libhal::util)
+
+foreach(demo IN LISTS DEMOS)
+    set(current_project ${demo}.elf)
+    message(STATUS "Generating Demo for \"${current_project}\"")
+    add_executable(${current_project} applications/${demo}.cpp)
+    target_include_directories(${current_project} PUBLIC .)
+    target_compile_features(${current_project} PRIVATE cxx_std_20)
+    target_link_libraries(${current_project} PRIVATE
+        libhal::${platform_library}
+        libhal::__device__
+        libhal::util
+        startup_code)
+    libhal_post_build(${current_project})
 endforeach()

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -19,13 +19,21 @@ from conan.tools.cmake import CMake, cmake_layout
 class demos(ConanFile):
     settings = "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualBuildEnv"
+    options = {"platform": ["ANY"]}
+    default_options = {"platform": "unspecified"}
+
+    def build_requirements(self):
+        self.tool_requires("libhal-cmake-util/1.0.0")
 
     def requirements(self):
-        self.requires("libhal-lpc40/2.0.0-alpha.3")
+        if str(self.options.platform).startswith("lpc40"):
+            self.requires("libhal-lpc40/2.0.0-alpha.3")
         self.requires("libhal-__device__/0.0.1")
+        self.requires("libhal-util/[^2.0.0]")
 
     def layout(self):
-        cmake_layout(self)
+        platform_directory = "build/" + str(self.options.platform)
+        cmake_layout(self, build_folder=platform_directory)
 
     def build(self):
         cmake = CMake(self)

--- a/demos/hardware_map.hpp
+++ b/demos/hardware_map.hpp
@@ -28,5 +28,5 @@ struct hardware_map
 // Application function must be implemented by one of the compilation units
 // (.cpp) files.
 hal::status application(hardware_map& p_map);
-hal::result<hardware_map> initialize_platform();
+hal::status initialize_processor();
 hal::result<hardware_map> initialize_platform();

--- a/include/libhal-__device__/__device__.hpp
+++ b/include/libhal-__device__/__device__.hpp
@@ -15,5 +15,6 @@
 #pragma once
 
 namespace hal::__device__ {
-// Add API here!
+class __device___replace_me
+{};
 }  // namespace hal::__device__

--- a/src/__device__.cpp
+++ b/src/__device__.cpp
@@ -1,3 +1,4 @@
 #include "libhal-__device__/__device__.hpp"
 
-// Add code implementation here!
+namespace hal::__device__ {
+}  // namespace hal::__device__

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,5 +20,4 @@ find_package(libhal-__device__ REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} main.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC .)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 target_link_libraries(${PROJECT_NAME} PRIVATE libhal::__device__)

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -23,6 +23,7 @@
 
 int main()
 {
+  hal::__device__::__device___replace_me bar;
 }
 
 namespace boost {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,4 +74,5 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   boost-ext-ut::ut
   libhal::libhal
   libhal::util
-  libhal::mock)
+  libhal::mock
+  libhal-__device__)


### PR DESCRIPTION
Workflows need special permissions to change workflows and the easiest and most portable method to support this is to simply ensure that ci.yml doesn't get modified. This is done by not including __device__ in that file.

Upgrade name to v5 git push.