### PR TITLE
:construction_worker: Remove "release" job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ name: ✅ CI
 on:
   workflow_dispatch:
   pull_request:
+  release:
+    types: [published]
   push:
-    tags:
-      - "*"
     branches:
       - main
   schedule:
@@ -48,18 +48,3 @@ jobs:
       processor_profile: https://github.com/libhal/libhal-armcortex.git
       platform_profile: https://github.com/libhal/libhal-lpc40.git
     secrets: inherit
-
-  # Add more build_<platform> blocks below for each platform you support
-
-  release:
-    # All jobs above MUST pass before creating a release
-    # Add more jobs to the `needs` section as they are added
-    needs: [ci, deploy, build_lpc4074, build_lpc4078]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          generate_release_notes: true


### PR DESCRIPTION
Releases trigger package uploads, so creating a release is redundant.