### PR TITLE
:test_tube: Add source files to test for coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![✅ Checks](https://github.com/libhal/libhal-__device__/actions/workflows/ci.yml/badge.svg)](https://github.com/libhal/libhal-__device__/actions/workflows/ci.yml)
 [![Coverage](https://libhal.github.io/libhal-__device__/coverage/coverage.svg)](https://libhal.github.io/libhal-__device__/coverage/)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/b084e6d5962d49a9afcb275d62cd6586)](https://www.codacy.com/gh/libhal/libhal-__device__/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=libhal/libhal-__device__&amp;utm_campaign=Badge_Grade)
 [![GitHub stars](https://img.shields.io/github/stars/libhal/libhal-__device__.svg)](https://github.com/libhal/libhal-__device__/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/libhal/libhal-__device__.svg)](https://github.com/libhal/libhal-__device__/network)
 [![GitHub issues](https://img.shields.io/github/issues/libhal/libhal-__device__.svg)](https://github.com/libhal/libhal-__device__/issues)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,7 +45,14 @@ find_package(libhal-util REQUIRED CONFIG)
 find_package(libhal-mock REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME}
+
+  # Source files
+  ../src/__device__.cpp
+
+  # Test source files
   __device__.test.cpp
+
+  # Main file for test
   main.test.cpp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC . ../include)
@@ -74,5 +81,4 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   boost-ext-ut::ut
   libhal::libhal
   libhal::util
-  libhal::mock
-  libhal-__device__)
+  libhal::mock)


### PR DESCRIPTION
Without recompiling the source files with coverage information, coverage will always report approx 100%.

Remove codeacy rating as our CI steps and standards will almost always ensure that codeacy is an A.