### PR TITLE
:construction_worker: Use ci/4.x.y version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ on:
   workflow_dispatch:
   pull_request:
   release:
-    types: [published]
+    types:
+      - published
+      - deleted
   push:
     branches:
       - main
@@ -27,22 +29,22 @@ on:
 
 jobs:
   ci:
-    uses: libhal/ci/.github/workflows/library.yml@4.1.0
+    uses: libhal/ci/.github/workflows/library.yml@4.x.y
     with:
       coverage: true
     secrets: inherit
   deploy:
-    uses: libhal/ci/.github/workflows/deploy.yml@4.1.0
+    uses: libhal/ci/.github/workflows/deploy.yml@4.x.y
     secrets: inherit
   build_lpc4074:
-    uses: libhal/ci/.github/workflows/demo_builder.yml@4.1.0
+    uses: libhal/ci/.github/workflows/demo_builder.yml@4.x.y
     with:
       profile: lpc4074
       processor_profile: https://github.com/libhal/libhal-armcortex.git
       platform_profile: https://github.com/libhal/libhal-lpc40.git
     secrets: inherit
   build_lpc4078:
-    uses: libhal/ci/.github/workflows/demo_builder.yml@4.1.0
+    uses: libhal/ci/.github/workflows/demo_builder.yml@4.x.y
     with:
       profile: lpc4078
       processor_profile: https://github.com/libhal/libhal-armcortex.git

--- a/conanfile.py
+++ b/conanfile.py
@@ -58,12 +58,12 @@ class libhal___device___conan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("libhal-cmake-util/1.0.0")
-        self.test_requires("libhal-mock/[^2.0.0]")
+        self.test_requires("libhal-mock/[^2.0.1]")
         self.test_requires("boost-ext-ut/1.1.9")
 
     def requirements(self):
         self.requires("libhal/[^2.0.0]")
-        self.requires("libhal-util/[^2.0.0]")
+        self.requires("libhal-util/[^3.0.0]")
 
     def layout(self):
         cmake_layout(self)

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -27,9 +27,9 @@ class demos(ConanFile):
 
     def requirements(self):
         if str(self.options.platform).startswith("lpc40"):
-            self.requires("libhal-lpc40/[^2.0.0]")
+            self.requires("libhal-lpc40/[^2.1.1]")
         self.requires("libhal-__device__/0.0.1")
-        self.requires("libhal-util/[^2.0.0]")
+        self.requires("libhal-util/[^3.0.0]")
 
     def layout(self):
         platform_directory = "build/" + str(self.options.platform)


### PR DESCRIPTION
The 4.x.y branch scheme means that this repo will get the latest changes to the ci that does not include breaking changes.