### PR TITLE
:technologist: Use boost::ut::suite for tests

### DIFF
--- a/tests/__device__.test.cpp
+++ b/tests/__device__.test.cpp
@@ -16,13 +16,12 @@
 
 #include <boost/ut.hpp>
 
-namespace hal::__device__ {  // NOLINT
-void __device___test()       // NOLINT
-{
+namespace hal::__device__ {                // NOLINT
+boost::ut::suite test___device__ = []() {  // NOLINT
   using namespace boost::ut;
   using namespace std::literals;
 
-  "__device__::create()"_test = []() {
+  "__device__::__device__()"_test = []() {
     // Setup
     // Exercise
     // Verify

--- a/tests/main.test.cpp
+++ b/tests/main.test.cpp
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace hal::__device__ {     // NOLINT
-extern void __device___test();  // NOLINT
-}  // namespace hal::__device__
-
 int main()
 {
-  hal::__device__::__device___test();
+  // Add non-suite tests here that must be called in a specific order.
+  // In general it is bad practice to couple unit tests with each other such
+  // that they need to be executed in order.
 }


### PR DESCRIPTION
suites execute automatically when included in a build, preventing developers from forgetting to call the test in `main.test.cpp`