### PR TITLE
:bug: Set terminate handler before calling init

### DIFF
--- a/demos/main.cpp
+++ b/demos/main.cpp
@@ -23,19 +23,19 @@ resource_list resources{};
 
 [[noreturn]] void terminate_handler() noexcept
 {
-
   if (not resources.status_led && not resources.clock) {
-    // spin here until debugger is connected
+    // spin here and wait for a debugger to be connected...
     while (true) {
       continue;
     }
   }
 
-  // Otherwise, blink the led in a pattern
+  // Safe access via ::value() is not necessary here since we have already
+  // checked the resources above.
+  auto& led = **resources.status_led;
+  auto& clock = **resources.clock;
 
-  auto& led = *resources.status_led.value();
-  auto& clock = *resources.clock.value();
-
+  // Otherwise, blink the led in a pattern...
   while (true) {
     using namespace std::chrono_literals;
     led.level(false);
@@ -51,16 +51,8 @@ resource_list resources{};
 
 int main()
 {
-  try {
-    resources = initialize_platform();
-  } catch (...) {
-    while (true) {
-      // halt here and wait for a debugger to connect
-      continue;
-    }
-  }
-
   hal::set_terminate(terminate_handler);
+  resources = initialize_platform();
 
   try {
     application(resources);

--- a/demos/platforms/lpc4078.cpp
+++ b/demos/platforms/lpc4078.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <libhal-armcortex/dwt_counter.hpp>
-#include <libhal-armcortex/startup.hpp>
-#include <libhal-armcortex/system_control.hpp>
-#include <libhal-lpc40/clock.hpp>
-#include <libhal-lpc40/constants.hpp>
-#include <libhal-lpc40/output_pin.hpp>
-#include <libhal-lpc40/uart.hpp>
+#include <libhal-arm-mcu/dwt_counter.hpp>
+#include <libhal-arm-mcu/lpc40/clock.hpp>
+#include <libhal-arm-mcu/lpc40/constants.hpp>
+#include <libhal-arm-mcu/lpc40/output_pin.hpp>
+#include <libhal-arm-mcu/lpc40/uart.hpp>
+#include <libhal-arm-mcu/startup.hpp>
+#include <libhal-arm-mcu/system_control.hpp>
 #include <libhal-util/as_bytes.hpp>
 
 #include <resource_list.hpp>
@@ -35,7 +35,7 @@ resource_list initialize_platform()
     hal::lpc40::get_frequency(hal::lpc40::peripheral::cpu));
 
   static std::array<hal::byte, 64> uart0_buffer{};
-  // Get and initialize UART0 for UART based logging
+
   static hal::lpc40::uart uart0(0,
                                 uart0_buffer,
                                 hal::serial::settings{

--- a/demos/platforms/stm32f103c8.cpp
+++ b/demos/platforms/stm32f103c8.cpp
@@ -14,14 +14,13 @@
 
 #include <libhal/units.hpp>
 
-#include <libhal-armcortex/dwt_counter.hpp>
-#include <libhal-armcortex/startup.hpp>
-#include <libhal-armcortex/system_control.hpp>
-
-#include <libhal-stm32f1/clock.hpp>
-#include <libhal-stm32f1/constants.hpp>
-#include <libhal-stm32f1/output_pin.hpp>
-#include <libhal-stm32f1/uart.hpp>
+#include <libhal-arm-mcu/dwt_counter.hpp>
+#include <libhal-arm-mcu/startup.hpp>
+#include <libhal-arm-mcu/stm32f1/clock.hpp>
+#include <libhal-arm-mcu/stm32f1/constants.hpp>
+#include <libhal-arm-mcu/stm32f1/output_pin.hpp>
+#include <libhal-arm-mcu/stm32f1/uart.hpp>
+#include <libhal-arm-mcu/system_control.hpp>
 
 #include <resource_list.hpp>
 


### PR DESCRIPTION
This way we can be trapped in the terminate handler if something in initialize_platform calls `std::terminate` directly.

Remove the redundant `= std::nullopt` assignment to `std::optional` since it default constructs as nullopt.